### PR TITLE
Improve menstruation and interaction handling

### DIFF
--- a/notfallkontrazeption-tool.html
+++ b/notfallkontrazeption-tool.html
@@ -568,7 +568,10 @@
                 comments.push('BMI >30 kg/m²: 1. Wahl Kupferspirale, 2. Wahl UPA 30 mg oder LNG doppelte Dosis (3 mg)');
             }
             if (answers.q8 === 'same-cycle') {
-                comments.push('Wiederholte Einnahme im selben Zyklus möglich. Bei Wechsel zwischen LNG und UPA verminderte Wirksamkeit – gleicher Wirkstoff bevorzugen.');
+                comments.push('Wiederholte Einnahme im selben Zyklus möglich. Interaktion zwischen LNG und UPA: verminderte Wirksamkeit möglich bei Einnahme von UPA innert 7 Tagen nach und 5 Tagen vor LNG – 1. Wahl Wiederholung gleicher Wirkstoff. Leicht erhöhtes Risiko für ektope Schwangerschaft, insbesondere bei entsprechender Vorgeschichte – über Alarmsymptome (Schmierblutungen, Krämpfe, Schmerzen im Unterleib) informieren.');
+            }
+            if (answers['q4c'] === 'lighter' || answers['q4c'] === 'absent') {
+                comments.push('Letzte Menstruation leichter, kürzer oder ausgeblieben: mögliche Anzeichen einer Schwangerschaft → Schwangerschaftstest empfohlen wenn Anzeichen vorhanden und weiterer uGV vor >21 Tagen');
             }
 
             if (comments.length) {
@@ -926,7 +929,7 @@
             
             // Drug interactions
             if (answers.q6 === 'glukokortikoide' || answers.q6 === 'gestagen') {
-                if (within72h) {
+                if (answers.q2 === '0-72h') {
                     return {
                         class: 'result-lng',
                         title: '💊 LNG 1,5 mg',


### PR DESCRIPTION
## Summary
- refine repeated-intake comment about interactions and ectopic pregnancy warning
- add menstruation warning for lighter or missing period
- avoid LNG recommendation >72h if UPA interaction exists

## Testing
- `tidy -errors notfallkontrazeption-tool.html`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eda6bcb308329a14e809814c43f3f